### PR TITLE
93-interim-email-address-digitalbuyingguidedigitalcabinet-officegovuk

### DIFF
--- a/ictcg/templates/500.html
+++ b/ictcg/templates/500.html
@@ -10,5 +10,5 @@
 
   <p>{% trans 'Try again later' %}</p>
 
-  <p>{% trans 'If the web address is correct or you selected a link or button and you wish to report the broken link' %} <a href="mailto:gdmp_ictguidelines@digital.cabinet-office.gov.uk">{% trans 'please contact us at gdmp_ictguidelines@digital.cabinet-office.gov.uk' %}</a></p>
+  <p>{% trans 'If the web address is correct or you selected a link or button and you wish to report the broken link' %} <a href="mailto:digitalbuyingguide@digital.cabinet-office.gov.uk">{% trans 'please contact us at digitalbuyingguide@digital.cabinet-office.gov.uk' %}</a></p>
 {% endblock %}

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -215,9 +215,9 @@ msgstr ""
 "informar el enlace roto,"
 
 #: ictcg/templates/500.html:13
-msgid "please contact us at gdmp_ictguidelines@digital.cabinet-office.gov.uk"
+msgid "please contact us at digitalbuyingguide@digital.cabinet-office.gov.uk"
 msgstr ""
-"comuníquese con nosotros a gdmp_ictguidelines@digital.cabinet-office.gov.uk"
+"comuníquese con nosotros a digitalbuyingguide@digital.cabinet-office.gov.uk"
 
 #: ictcg/templates/base.html:37
 msgid "Skip to main content"

--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -217,8 +217,8 @@ msgstr ""
 "melaporkan tautan yang rusak,"
 
 #: ictcg/templates/500.html:13
-msgid "please contact us at gdmp_ictguidelines@digital.cabinet-office.gov.uk"
-msgstr "hubungilah kami di gdmp_ictguidelines@digital.cabinet-office.gov.uk"
+msgid "please contact us at digitalbuyingguide@digital.cabinet-office.gov.uk"
+msgstr "hubungilah kami di digitalbuyingguide@digital.cabinet-office.gov.uk"
 
 #: ictcg/templates/base.html:37
 msgid "Skip to main content"


### PR DESCRIPTION
Change email on error page and in translations
https://trello.com/c/rwtXOGDx/93-interim-email-address-digitalbuyingguidedigitalcabinet-officegovuk