### PR TITLE
99-google-analytics-to-top-of-html-to-trigger-page-load-stats

### DIFF
--- a/frontend/javascripts/application.js
+++ b/frontend/javascripts/application.js
@@ -5,8 +5,6 @@ import Accordion from './components/accordion'
 import Header from './components/header'
 import Cookie from './components/cookie'
 import { Button } from 'govuk-frontend'
-import { getCookieByName } from './utils/cookie'
-import { loadGoogleAnalytics } from './google-analytics'
 
 (function () {
   var $accordions = document.querySelectorAll('[data-module="govuk-accordion"]')
@@ -33,15 +31,4 @@ import { loadGoogleAnalytics } from './google-analytics'
     new Cookie($cookiebanner).init()
   }
 
-  if (getCookieByName('analytics') === 'true') {
-    const gaID = document.getElementsByTagName('body')[0].getAttribute('data-ga-id')
-
-    loadGoogleAnalytics(gaID)
-    window.dataLayer = window.dataLayer || []
-
-    function gtag(){dataLayer.push(arguments)} /* eslint-disable-line */
-
-    gtag('js', new Date())
-    gtag('config', gaID)
-  }
 })()

--- a/frontend/javascripts/google-analytics.js
+++ b/frontend/javascripts/google-analytics.js
@@ -1,8 +1,0 @@
-export const loadGoogleAnalytics = (gaID) => {
-  var ga = document.createElement('script')
-  ga.type = 'text/javascript'
-  ga.async = true
-  ga.src = `https://www.googletagmanager.com/gtag/js?id=${gaID}`
-  var s = document.getElementsByTagName('script')[0]
-  s.parentNode.insertBefore(ga, s)
-}

--- a/frontend/javascripts/utils/cookie.js
+++ b/frontend/javascripts/utils/cookie.js
@@ -1,5 +1,0 @@
-export const getCookieByName = (name) => {
-  const value = `; ${document.cookie}`
-  const parts = value.split(`; ${name}=`)
-  if (parts.length === 2) return parts.pop().split(';').shift()
-}

--- a/ictcg/templates/base.html
+++ b/ictcg/templates/base.html
@@ -5,6 +5,22 @@
 
 <head>
   <meta charset="utf-8" />
+
+  <!-- Disable Google Analytics unless explicit consent set in cookie-->
+  <script>
+    window['ga-disable-{{ analytics_id }}'] = Object.fromEntries( document.cookie.split('; ').map( x => x.split('=')) ).analytics !== "true"
+  </script>>
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ analytics_id }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '{{ analytics_id }}');
+  </script>
+
   <title>
     {% block title %}
       {% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}
@@ -32,7 +48,7 @@
 </head>
 
 {% get_analytics_id as analytics_id %}
-<body class="govuk-template__body {% block body_class %}{% endblock %}" data-ga-id="{{ analytics_id }}">
+<body class="govuk-template__body {% block body_class %}{% endblock %}">
 
   <a href="#main-title" class="govuk-skip-link">{% trans 'Skip to main content' %}</a>
 


### PR DESCRIPTION
https://trello.com/c/pSX5qb18/99-google-analytics-to-top-of-html-to-trigger-page-load-stats

* Remove Google Analytics code from bottom of `application.js`
* Trigger in head tag as per https://support.google.com/analytics/answer/1009683?hl=en
* Disable analytics based on cookie value as per https://developers.google.com/analytics/devguides/collection/gtagjs/user-opt-out